### PR TITLE
Add ThemeProvider wrapper and apply globally

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export type ThemeProviderProps = React.ComponentProps<typeof NextThemesProvider>;
+
+const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => (
+  <NextThemesProvider attribute="class" defaultTheme="system" enableSystem {...props}>
+    {children}
+  </NextThemesProvider>
+);
+
+export { ThemeProvider };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
+import { ThemeProvider } from "./components/ThemeProvider";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- add a dedicated ThemeProvider wrapper that configures next-themes defaults
- wrap the application root with the ThemeProvider so Sonner has access to the theme context

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db09b51e788327b5fa5f70283cf2b5