### PR TITLE
Ensure protected routes wait for user role resolution

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -11,8 +11,10 @@ const ProtectedRoute = ({ children, allowedRoles }: ProtectedRouteProps) => {
   const { user, userRole, loading } = useAuth();
   const navigate = useNavigate();
 
+  const isRolePending = Boolean(allowedRoles && user && !userRole);
+
   useEffect(() => {
-    if (!loading) {
+    if (!loading && !isRolePending) {
       if (!user) {
         navigate('/auth');
         return;
@@ -23,9 +25,9 @@ const ProtectedRoute = ({ children, allowedRoles }: ProtectedRouteProps) => {
         return;
       }
     }
-  }, [user, userRole, loading, navigate, allowedRoles]);
+  }, [user, userRole, loading, navigate, allowedRoles, isRolePending]);
 
-  if (loading) {
+  if (loading || isRolePending) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-pulse-medical">


### PR DESCRIPTION
## Summary
- keep the auth provider in a loading state until the user profile and role have been fetched
- clear cached profile/role information when fetching fails to avoid exposing stale permissions
- show the protected route fallback while a required role is still being resolved

## Testing
- npm run lint *(fails: pre-existing lint issues in ui components and tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68db0a5e7dbc8327ade328d4fb95b703