### PR TITLE
Add section anchors for hero and feature navigation

### DIFF
--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -72,6 +72,15 @@ const Features = () => {
           </p>
         </div>
 
+        <div id="sobre" className="max-w-3xl mx-auto text-center mb-20 space-y-4">
+          <h3 className="text-2xl font-bold">Sobre o AgendarBrasil</h3>
+          <p className="text-muted-foreground">
+            Conectamos pacientes, profissionais e clínicas em uma única plataforma intuitiva.
+            Com tecnologia de ponta, oferecemos ferramentas para otimizar o cuidado em saúde e
+            garantir experiências memoráveis em cada consulta.
+          </p>
+        </div>
+
         {/* Para Pacientes */}
         <div className="mb-20">
           <div className="text-center mb-12">
@@ -97,7 +106,7 @@ const Features = () => {
         </div>
 
         {/* Para Profissionais */}
-        <div className="mb-20">
+        <div id="profissionais" className="mb-20">
           <div className="text-center mb-12">
             <h3 className="text-2xl font-bold mb-4">Para Profissionais de Saúde</h3>
             <p className="text-muted-foreground">Otimize seu consultório e melhore o atendimento</p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,8 +3,15 @@ import { Calendar, Shield, Smartphone, Users } from "lucide-react";
 import heroImage from "@/assets/hero-medical.jpg";
 
 const Hero = () => {
+  const scrollToSection = (sectionId: string) => {
+    const element = typeof document !== "undefined" ? document.getElementById(sectionId) : null;
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
   return (
-    <section className="relative min-h-screen flex items-center bg-gradient-subtle">
+    <section id="agenda" className="relative min-h-screen flex items-center bg-gradient-subtle">
       <div className="container mx-auto px-4 py-20">
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           <div className="space-y-8">
@@ -19,11 +26,21 @@ const Hero = () => {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4">
-              <Button variant="medical" size="lg" className="text-lg px-8 py-6">
+              <Button
+                variant="medical"
+                size="lg"
+                className="text-lg px-8 py-6"
+                onClick={() => scrollToSection("agenda")}
+              >
                 <Calendar className="h-5 w-5 mr-2" />
                 Agendar Consulta
               </Button>
-              <Button variant="outline" size="lg" className="text-lg px-8 py-6">
+              <Button
+                variant="outline"
+                size="lg"
+                className="text-lg px-8 py-6"
+                onClick={() => scrollToSection("profissionais")}
+              >
                 Sou Profissional
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- add agenda anchor and smooth scrolling buttons to the hero section
- introduce an about section and anchor the professionals block for in-page navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db0bed8e148327866838fff17d424a