### PR TITLE
Add elegant Tailwind shadow token

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -87,6 +87,7 @@ export default {
         'medical': 'var(--shadow-medical)',
         'card': 'var(--shadow-card)',
         'button': 'var(--shadow-button)',
+        'elegant': '0 12px 24px -12px rgba(15, 23, 42, 0.35), 0 20px 40px -20px rgba(15, 23, 42, 0.3)',
       },
       transitionTimingFunction: {
         'medical': 'var(--transition-medical)',


### PR DESCRIPTION
## Summary
- add an `elegant` box shadow token to Tailwind for deeper card elevation
- rebuild Tailwind assets so the `shadow-elegant` utility is emitted for auth and unauthorized pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db2523e7f08327a5acc0a9e3e170de