### PR TITLE
Revamp 404 page with branded styling

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,7 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Heart, ArrowLeft, Home } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 const NotFound = () => {
   const location = useLocation();
@@ -9,13 +11,46 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
-          Return to Home
-        </a>
+    <div className="min-h-screen bg-gradient-subtle flex items-center justify-center px-4 py-12">
+      <div className="container">
+        <div className="mx-auto max-w-3xl text-center space-y-10">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex items-center gap-3">
+              <Heart className="h-10 w-10 text-health" aria-hidden="true" />
+              <span className="text-3xl md:text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent">
+                AgendarBrasil
+              </span>
+            </div>
+            <span className="text-sm font-semibold tracking-[0.2em] uppercase text-primary/80">
+              Erro 404
+            </span>
+          </div>
+
+          <div className="space-y-6">
+            <h1 className="text-4xl md:text-6xl font-bold leading-tight text-foreground">
+              Página não encontrada
+            </h1>
+            <p className="text-xl text-muted-foreground leading-relaxed">
+              A rota <span className="font-semibold text-foreground">{location.pathname}</span> não existe ou foi
+              movida. Use os atalhos abaixo para continuar aproveitando a plataforma.
+            </p>
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Button asChild variant="medical" size="lg" className="text-lg px-8 py-6">
+              <Link to="/">
+                <Home className="mr-2 h-5 w-5" aria-hidden="true" />
+                Voltar para a página inicial
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="text-lg px-8 py-6">
+              <Link to="/auth">
+                <ArrowLeft className="mr-2 h-5 w-5" aria-hidden="true" />
+                Entrar na plataforma
+              </Link>
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle the NotFound view to use branded gradients, typography, and iconography
- add primary and secondary actions using the shared Button primitive for consistent interaction affordances

## Testing
- npm run lint *(fails: existing lint issues in shared UI files and useAuth hook)*

------
https://chatgpt.com/codex/tasks/task_b_68db252dba4c8327ae05ada4dbdd2fe2