### PR TITLE
Add Supabase scheduling schema and booking UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
+import Schedule from "./pages/Schedule";
 import Unauthorized from "./pages/Unauthorized";
 import NotFound from "./pages/NotFound";
 
@@ -21,6 +22,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/auth" element={<Auth />} />
+            <Route path="/schedule" element={<Schedule />} />
             <Route path="/unauthorized" element={<Unauthorized />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,10 @@ const Header = () => {
     navigate('/');
   };
 
+  const goToSchedule = () => {
+    navigate('/schedule');
+  };
+
   const getUserInitials = () => {
     if (profile?.first_name && profile?.last_name) {
       return `${profile.first_name[0]}${profile.last_name[0]}`.toUpperCase();
@@ -65,9 +69,13 @@ const Header = () => {
         </div>
 
         <nav className="hidden md:flex items-center space-x-6">
-          <a href="#agenda" className="text-sm font-medium text-muted-foreground hover:text-primary transition-smooth">
+          <button
+            type="button"
+            onClick={goToSchedule}
+            className="text-sm font-medium text-muted-foreground hover:text-primary transition-smooth"
+          >
             Agendar Consulta
-          </a>
+          </button>
           <a href="#profissionais" className="text-sm font-medium text-muted-foreground hover:text-primary transition-smooth">
             Para Profissionais
           </a>
@@ -77,6 +85,15 @@ const Header = () => {
         </nav>
 
         <div className="flex items-center space-x-1 sm:space-x-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="hidden sm:flex text-xs sm:text-sm px-2 sm:px-4"
+            onClick={goToSchedule}
+          >
+            <Calendar className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
+            <span className="hidden sm:inline">Agendar</span>
+          </Button>
           {user ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,8 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { Calendar, Shield, Smartphone, Users } from "lucide-react";
 import heroImage from "@/assets/hero-medical.jpg";
+import { useNavigate } from "react-router-dom";
 
 const Hero = () => {
+  const navigate = useNavigate();
+
   const scrollToSection = (sectionId: string) => {
     const element = typeof document !== "undefined" ? document.getElementById(sectionId) : null;
     if (element) {
@@ -30,7 +33,7 @@ const Hero = () => {
                 variant="medical"
                 size="lg"
                 className="text-lg px-8 py-6"
-                onClick={() => scrollToSection("agenda")}
+                onClick={() => navigate("/schedule")}
               >
                 <Calendar className="h-5 w-5 mr-2" />
                 Agendar Consulta

--- a/src/integrations/supabase/react-query/schedule.ts
+++ b/src/integrations/supabase/react-query/schedule.ts
@@ -1,0 +1,241 @@
+import { useEffect, useMemo } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import { endOfDay, formatISO, startOfDay } from "date-fns";
+import { supabase } from "../client";
+import type { Tables } from "../types";
+
+export type ProviderRow = Tables<"providers">;
+export type ProviderProfileRow = Tables<"profiles">;
+export type AvailabilitySlotRow = Tables<"availability_slots">;
+export type AppointmentRow = Tables<"appointments">;
+
+export interface ProviderWithProfile extends ProviderRow {
+  profile: ProviderProfileRow | null;
+}
+
+export interface AppointmentWithRelations extends AppointmentRow {
+  slot: AvailabilitySlotRow | null;
+  provider: (ProviderRow & { profile: ProviderProfileRow | null }) | null;
+}
+
+export interface AvailabilitySlotFilters {
+  date?: Date;
+  includeUnavailable?: boolean;
+}
+
+export const providerKeys = {
+  all: ["providers"] as const,
+};
+
+export const slotKeys = {
+  all: ["availability_slots"] as const,
+  list: (providerId?: string, dayKey?: string) =>
+    ["availability_slots", providerId ?? "all", dayKey ?? "all"] as const,
+};
+
+export const appointmentKeys = {
+  all: ["appointments"] as const,
+  list: (scope?: string) => ["appointments", scope ?? "all"] as const,
+};
+
+export const useProvidersQuery = (): UseQueryResult<ProviderWithProfile[], Error> =>
+  useQuery({
+    queryKey: providerKeys.all,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("providers")
+        .select("*, profile:profiles(*)")
+        .eq("is_active", true)
+        .order("created_at", { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []).map((provider) => ({
+        ...provider,
+        profile: (provider as { profile?: ProviderProfileRow | null }).profile ?? null,
+      })) as ProviderWithProfile[];
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useAvailabilitySlots = (
+  providerId?: string,
+  filters?: AvailabilitySlotFilters,
+): UseQueryResult<AvailabilitySlotRow[], Error> => {
+  const queryClient = useQueryClient();
+  const dayKey = useMemo(() => {
+    if (!filters?.date) return "all";
+    return formatISO(startOfDay(filters.date), { representation: "date" });
+  }, [filters?.date]);
+
+  const query = useQuery({
+    queryKey: slotKeys.list(providerId, dayKey),
+    enabled: Boolean(providerId),
+    queryFn: async () => {
+      if (!providerId) {
+        return [] as AvailabilitySlotRow[];
+      }
+
+      let queryBuilder = supabase
+        .from("availability_slots")
+        .select("*")
+        .eq("provider_id", providerId)
+        .order("start_time", { ascending: true });
+
+      const nowIso = new Date().toISOString();
+      queryBuilder = queryBuilder.gte("start_time", nowIso);
+
+      if (filters?.date) {
+        const start = startOfDay(filters.date).toISOString();
+        const end = endOfDay(filters.date).toISOString();
+        queryBuilder = queryBuilder.gte("start_time", start).lt("start_time", end);
+      }
+
+      if (!filters?.includeUnavailable) {
+        queryBuilder = queryBuilder.eq("status", "available");
+      }
+
+      const { data, error } = await queryBuilder;
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as AvailabilitySlotRow[];
+    },
+  });
+
+  useEffect(() => {
+    if (!providerId) return;
+
+    const channel = supabase
+      .channel(`availability-slots-${providerId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "availability_slots",
+          filter: `provider_id=eq.${providerId}`,
+        },
+        () => {
+          queryClient.invalidateQueries({
+            queryKey: slotKeys.list(providerId, dayKey),
+            exact: true,
+          });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [providerId, dayKey, queryClient]);
+
+  return query;
+};
+
+export const useMyAppointmentsQuery = (
+  userId?: string,
+  enabled = true,
+): UseQueryResult<AppointmentWithRelations[], Error> => {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: appointmentKeys.list(userId ?? "anonymous"),
+    enabled: Boolean(userId) && enabled,
+    queryFn: async () => {
+      if (!userId) {
+        return [] as AppointmentWithRelations[];
+      }
+
+      const { data, error } = await supabase
+        .from("appointments")
+        .select("*, slot:availability_slots(*), provider:providers(*, profile:profiles(*))")
+        .eq("patient_id", userId)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []).map((appointment) => ({
+        ...appointment,
+        slot: (appointment as { slot?: AvailabilitySlotRow | null }).slot ?? null,
+        provider: (appointment as {
+          provider?: (ProviderRow & { profile?: ProviderProfileRow | null }) | null;
+        }).provider
+          ? {
+              ...(appointment as {
+                provider: ProviderRow & { profile?: ProviderProfileRow | null } | null;
+              }).provider!,
+              profile: ((appointment as {
+                provider?: ProviderRow & { profile?: ProviderProfileRow | null } | null;
+              }).provider?.profile ?? null) as ProviderProfileRow | null,
+            }
+          : null,
+      })) as AppointmentWithRelations[];
+    },
+  });
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const channel = supabase
+      .channel(`appointments-${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "appointments",
+          filter: `patient_id=eq.${userId}`,
+        },
+        () => {
+          queryClient.invalidateQueries({ queryKey: appointmentKeys.list(userId), exact: true });
+          queryClient.invalidateQueries({ queryKey: slotKeys.all, exact: false });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId, queryClient]);
+
+  return query;
+};
+
+export interface BookAppointmentVariables {
+  slotId: string;
+  notes?: string;
+}
+
+export const useBookAppointmentMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ slotId, notes }: BookAppointmentVariables) => {
+      const { data, error } = await supabase.rpc("book_appointment", {
+        slot_id: slotId,
+        notes: notes ?? null,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      return data as AppointmentRow;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: slotKeys.all, exact: false });
+      queryClient.invalidateQueries({ queryKey: appointmentKeys.all, exact: false });
+    },
+  });
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,69 @@ export type Database = {
   }
   public: {
     Tables: {
+      appointments: {
+        Row: {
+          created_at: string
+          id: string
+          notes: string | null
+          patient_id: string
+          provider_id: string
+          slot_id: string
+          status: Database["public"]["Enums"]["appointment_status"]
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          notes?: string | null
+          patient_id: string
+          provider_id: string
+          slot_id: string
+          status?: Database["public"]["Enums"]["appointment_status"]
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          notes?: string | null
+          patient_id?: string
+          provider_id?: string
+          slot_id?: string
+          status?: Database["public"]["Enums"]["appointment_status"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      availability_slots: {
+        Row: {
+          created_at: string
+          end_time: string
+          id: string
+          provider_id: string
+          start_time: string
+          status: Database["public"]["Enums"]["slot_status"]
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          end_time: string
+          id?: string
+          provider_id: string
+          start_time: string
+          status?: Database["public"]["Enums"]["slot_status"]
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          end_time?: string
+          id?: string
+          provider_id?: string
+          start_time?: string
+          status?: Database["public"]["Enums"]["slot_status"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           avatar_url: string | null
@@ -56,6 +119,42 @@ export type Database = {
         }
         Relationships: []
       }
+      providers: {
+        Row: {
+          city: string | null
+          created_at: string
+          id: string
+          is_active: boolean
+          profile_id: string
+          specialty: string | null
+          state: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          city?: string | null
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          profile_id: string
+          specialty?: string | null
+          state?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          city?: string | null
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          profile_id?: string
+          specialty?: string | null
+          state?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_roles: {
         Row: {
           created_at: string
@@ -86,6 +185,19 @@ export type Database = {
         Args: { _user_id: string }
         Returns: Database["public"]["Enums"]["app_role"]
       }
+      book_appointment: {
+        Args: {
+          notes?: string | null
+          slot_id: string
+        }
+        Returns: Database["public"]["Tables"]["appointments"]["Row"]
+      }
+      cancel_appointment: {
+        Args: {
+          appointment_id: string
+        }
+        Returns: Database["public"]["Tables"]["appointments"]["Row"]
+      }
       has_role: {
         Args: {
           _role: Database["public"]["Enums"]["app_role"]
@@ -96,6 +208,8 @@ export type Database = {
     }
     Enums: {
       app_role: "paciente" | "medico" | "admin"
+      appointment_status: "booked" | "cancelled" | "completed"
+      slot_status: "available" | "booked" | "unavailable"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -224,6 +338,8 @@ export const Constants = {
   public: {
     Enums: {
       app_role: ["paciente", "medico", "admin"],
+      appointment_status: ["booked", "cancelled", "completed"],
+      slot_status: ["available", "booked", "unavailable"],
     },
   },
 } as const

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,0 +1,607 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import {
+  AppointmentWithRelations,
+  AvailabilitySlotRow,
+  ProviderWithProfile,
+  useAvailabilitySlots,
+  useBookAppointmentMutation,
+  useMyAppointmentsQuery,
+  useProvidersQuery,
+} from "@/integrations/supabase/react-query/schedule";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  AlertCircle,
+  Calendar as CalendarIcon,
+  CheckCircle2,
+  Clock,
+  MapPin,
+  ShieldCheck,
+  Stethoscope,
+  User,
+} from "lucide-react";
+import { format, isBefore, startOfDay } from "date-fns";
+
+const Schedule = () => {
+  const navigate = useNavigate();
+  const { user, userRole, loading: authLoading } = useAuth();
+  const { toast } = useToast();
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedSpecialty, setSelectedSpecialty] = useState<string | undefined>();
+  const [selectedCity, setSelectedCity] = useState<string | undefined>();
+  const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+  const [selectedSlot, setSelectedSlot] = useState<AvailabilitySlotRow | null>(null);
+  const [bookingNotes, setBookingNotes] = useState("");
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isAuthDialogOpen, setIsAuthDialogOpen] = useState(false);
+  const [isRoleDialogOpen, setIsRoleDialogOpen] = useState(false);
+
+  const providersQuery = useProvidersQuery();
+  const slotsQuery = useAvailabilitySlots(selectedProviderId ?? undefined, {
+    date: selectedDate,
+  });
+  const appointmentsQuery = useMyAppointmentsQuery(user?.id, Boolean(user));
+  const bookAppointment = useBookAppointmentMutation();
+
+  const availableSpecialties = useMemo(() => {
+    if (!providersQuery.data) return [] as string[];
+    const specialties = new Set<string>();
+    providersQuery.data.forEach((provider) => {
+      const specialty = provider.profile?.specialty;
+      if (specialty) {
+        specialties.add(specialty);
+      }
+    });
+    return Array.from(specialties).sort();
+  }, [providersQuery.data]);
+
+  const availableCities = useMemo(() => {
+    if (!providersQuery.data) return [] as string[];
+    const cities = new Set<string>();
+    providersQuery.data.forEach((provider) => {
+      if (provider.city) {
+        cities.add(provider.city);
+      }
+    });
+    return Array.from(cities).sort();
+  }, [providersQuery.data]);
+
+  const filteredProviders = useMemo(() => {
+    if (!providersQuery.data) return [] as ProviderWithProfile[];
+    return providersQuery.data.filter((provider) => {
+      const fullName = `${provider.profile?.first_name ?? ""} ${provider.profile?.last_name ?? ""}`
+        .trim()
+        .toLowerCase();
+      const specialty = provider.profile?.specialty?.toLowerCase() ?? "";
+      const city = provider.city?.toLowerCase() ?? "";
+      const search = searchTerm.toLowerCase().trim();
+
+      const matchesSearch =
+        !search ||
+        fullName.includes(search) ||
+        specialty.includes(search) ||
+        city.includes(search);
+      const matchesSpecialty = !selectedSpecialty || provider.profile?.specialty === selectedSpecialty;
+      const matchesCity = !selectedCity || provider.city === selectedCity;
+
+      return matchesSearch && matchesSpecialty && matchesCity;
+    });
+  }, [providersQuery.data, searchTerm, selectedSpecialty, selectedCity]);
+
+  useEffect(() => {
+    if (filteredProviders.length === 0) {
+      if (selectedProviderId !== null) {
+        setSelectedProviderId(null);
+      }
+      return;
+    }
+
+    if (!selectedProviderId) {
+      setSelectedProviderId(filteredProviders[0].id);
+    }
+  }, [filteredProviders, selectedProviderId]);
+
+  const selectedProvider = useMemo(
+    () => filteredProviders.find((provider) => provider.id === selectedProviderId) ?? null,
+    [filteredProviders, selectedProviderId],
+  );
+
+  const upcomingAppointments = useMemo(() => {
+    if (!appointmentsQuery.data) return [] as AppointmentWithRelations[];
+    const now = new Date();
+    return appointmentsQuery.data
+      .filter((appointment) => appointment.slot?.start_time && !isBefore(new Date(appointment.slot.start_time), now))
+      .sort((a, b) => {
+        const aTime = new Date(a.slot?.start_time ?? 0).getTime();
+        const bTime = new Date(b.slot?.start_time ?? 0).getTime();
+        return aTime - bTime;
+      })
+      .slice(0, 3);
+  }, [appointmentsQuery.data]);
+
+  const handleSlotSelection = (slot: AvailabilitySlotRow) => {
+    if (!user) {
+      setIsAuthDialogOpen(true);
+      return;
+    }
+
+    if (userRole && userRole !== "paciente") {
+      setIsRoleDialogOpen(true);
+      return;
+    }
+
+    setSelectedSlot(slot);
+    setIsConfirmOpen(true);
+  };
+
+  const handleConfirmBooking = async () => {
+    if (!selectedSlot) return;
+
+    try {
+      await bookAppointment.mutateAsync({
+        slotId: selectedSlot.id,
+        notes: bookingNotes,
+      });
+
+      toast({
+        title: "Consulta agendada com sucesso!",
+        description: "Você receberá a confirmação no seu e-mail cadastrado.",
+      });
+
+      setIsConfirmOpen(false);
+      setBookingNotes("");
+      setSelectedSlot(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Não foi possível concluir o agendamento.";
+      toast({
+        title: "Erro ao agendar",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const renderProviderCard = (provider: ProviderWithProfile) => {
+    const fullName = `${provider.profile?.first_name ?? ""} ${provider.profile?.last_name ?? ""}`.trim() || "Profissional";
+    return (
+      <Card
+        key={provider.id}
+        className={cn("cursor-pointer transition-smooth", {
+          "border-primary shadow-medical": provider.id === selectedProviderId,
+        })}
+        onClick={() => setSelectedProviderId(provider.id)}
+      >
+        <CardHeader className="space-y-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg font-semibold flex items-center gap-2">
+              <Stethoscope className="h-4 w-4 text-health" />
+              {fullName}
+            </CardTitle>
+            {provider.profile?.specialty && <Badge variant="outline">{provider.profile.specialty}</Badge>}
+          </div>
+          <CardDescription className="flex items-center gap-2 text-muted-foreground">
+            <MapPin className="h-4 w-4" />
+            {provider.city ? `${provider.city}${provider.state ? `, ${provider.state}` : ""}` : "Localização não informada"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground line-clamp-3">
+            {provider.profile?.bio ?? "Esse profissional ainda não adicionou uma biografia."}
+          </p>
+          <Button variant={provider.id === selectedProviderId ? "medical" : "outline"} className="w-full">
+            {provider.id === selectedProviderId ? "Selecionado" : "Selecionar"}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  const renderSlotButton = (slot: AvailabilitySlotRow) => {
+    const start = format(new Date(slot.start_time), "HH:mm");
+    const end = format(new Date(slot.end_time), "HH:mm");
+    return (
+      <Button
+        key={slot.id}
+        variant="outline"
+        className="w-full justify-start"
+        onClick={() => handleSlotSelection(slot)}
+        disabled={slot.status !== "available" || bookAppointment.isPending}
+      >
+        <Clock className="mr-2 h-4 w-4 text-primary" />
+        {start} - {end}
+      </Button>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+      <main className="container mx-auto px-4 py-10 space-y-10">
+        <section className="space-y-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <h1 className="text-3xl font-bold">Agende sua consulta</h1>
+              <p className="text-muted-foreground max-w-2xl">
+                Encontre profissionais, escolha o melhor horário e confirme sua consulta em poucos cliques.
+              </p>
+            </div>
+            {!user && !authLoading && (
+              <Button size="lg" variant="medical" onClick={() => navigate("/auth")}>Criar conta gratuita</Button>
+            )}
+          </div>
+
+          {appointmentsQuery.isLoading ? (
+            <Card>
+              <CardContent className="space-y-3 py-6">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-4 w-1/2" />
+              </CardContent>
+            </Card>
+          ) : upcomingAppointments.length > 0 ? (
+            <Card className="border-primary/40 bg-primary/5">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-primary">
+                  <CheckCircle2 className="h-5 w-5" />
+                  Próximas consultas
+                </CardTitle>
+                <CardDescription className="text-primary/80">
+                  Acompanhe seus agendamentos confirmados em tempo real.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {upcomingAppointments.map((appointment) => {
+                  const slotDate = appointment.slot ? new Date(appointment.slot.start_time) : null;
+                  const providerName = `${appointment.provider?.profile?.first_name ?? ""} ${appointment.provider?.profile?.last_name ?? ""}`
+                    .trim() || "Profissional";
+                  return (
+                    <div key={appointment.id} className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-background/80 p-4">
+                      <div className="flex flex-wrap items-center gap-3">
+                        <Badge variant="outline" className="border-primary text-primary">
+                          {appointment.status === "booked" ? "Confirmada" : appointment.status}
+                        </Badge>
+                        {slotDate && (
+                          <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <CalendarIcon className="h-4 w-4" />
+                            {format(slotDate, "dd/MM/yyyy 'às' HH:mm")}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                        <Stethoscope className="h-4 w-4" />
+                        {providerName}
+                        {appointment.provider?.city && (
+                          <span className="flex items-center gap-1">
+                            <MapPin className="h-4 w-4" />
+                            {appointment.provider.city}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          ) : (
+            <Alert>
+              <ShieldCheck className="h-4 w-4" />
+              <AlertTitle>Agende com tranquilidade</AlertTitle>
+              <AlertDescription>
+                Assim que você confirmar uma consulta, ela aparecerá aqui com atualizações em tempo real.
+              </AlertDescription>
+            </Alert>
+          )}
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[340px_1fr]">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Filtros</CardTitle>
+                <CardDescription>Personalize a busca para encontrar o especialista ideal.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-muted-foreground" htmlFor="search">
+                    Buscar por nome ou especialidade
+                  </label>
+                  <Input
+                    id="search"
+                    placeholder="Digite o nome do profissional"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-muted-foreground">Especialidade</label>
+                  <Select
+                    value={selectedSpecialty ?? ""}
+                    onValueChange={(value) => setSelectedSpecialty(value || undefined)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Todas as especialidades" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">Todas</SelectItem>
+                      {availableSpecialties.map((specialty) => (
+                        <SelectItem key={specialty} value={specialty}>
+                          {specialty}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-muted-foreground">Cidade</label>
+                  <Select
+                    value={selectedCity ?? ""}
+                    onValueChange={(value) => setSelectedCity(value || undefined)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Todas as cidades" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">Todas</SelectItem>
+                      {availableCities.map((city) => (
+                        <SelectItem key={city} value={city}>
+                          {city}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-muted-foreground">Data</label>
+                  <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" className="w-full justify-start text-left font-normal">
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        {selectedDate ? format(selectedDate, "dd/MM/yyyy") : "Escolha uma data"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-auto p-0">
+                      <Calendar
+                        mode="single"
+                        selected={selectedDate}
+                        onSelect={(date) => {
+                          setSelectedDate(date ?? undefined);
+                          setIsCalendarOpen(false);
+                        }}
+                        disabled={(date) => isBefore(startOfDay(date), startOfDay(new Date()))}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Profissionais</CardTitle>
+                <CardDescription>Selecione um profissional para visualizar os horários disponíveis.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {providersQuery.isLoading ? (
+                  <div className="space-y-3">
+                    <Skeleton className="h-20 w-full" />
+                    <Skeleton className="h-20 w-full" />
+                  </div>
+                ) : providersQuery.error ? (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Não foi possível carregar os profissionais</AlertTitle>
+                    <AlertDescription>
+                      {providersQuery.error.message || "Tente atualizar a página em alguns instantes."}
+                    </AlertDescription>
+                  </Alert>
+                ) : filteredProviders.length > 0 ? (
+                  <ScrollArea className="h-[420px] pr-3">
+                    <div className="space-y-4">
+                      {filteredProviders.map((provider) => renderProviderCard(provider))}
+                    </div>
+                  </ScrollArea>
+                ) : (
+                  <Alert>
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Nenhum profissional encontrado</AlertTitle>
+                    <AlertDescription>
+                      Ajuste os filtros de busca ou tente novamente mais tarde.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Horários disponíveis</CardTitle>
+                <CardDescription>
+                  Escolha um horário e confirme a consulta. As reservas são atualizadas em tempo real.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {slotsQuery.isLoading ? (
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                  </div>
+                ) : slotsQuery.error ? (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Erro ao buscar horários</AlertTitle>
+                    <AlertDescription>
+                      {slotsQuery.error.message || "Tente novamente mais tarde."}
+                    </AlertDescription>
+                  </Alert>
+                ) : selectedProvider ? (
+                  slotsQuery.data && slotsQuery.data.length > 0 ? (
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                      {slotsQuery.data.map((slot) => renderSlotButton(slot))}
+                    </div>
+                  ) : (
+                    <Alert>
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertTitle>Sem horários disponíveis</AlertTitle>
+                      <AlertDescription>
+                        Escolha outra data ou selecione um profissional diferente para ver novas opções.
+                      </AlertDescription>
+                    </Alert>
+                  )
+                ) : (
+                  <Alert>
+                    <User className="h-4 w-4" />
+                    <AlertTitle>Selecione um profissional</AlertTitle>
+                    <AlertDescription>
+                      Use a lista ao lado para escolher um profissional e visualizar seus horários.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Dúvidas frequentes</CardTitle>
+                <CardDescription>Informações importantes sobre o processo de agendamento.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <div className="flex items-start gap-3">
+                  <ShieldCheck className="mt-1 h-4 w-4 text-primary" />
+                  <p>As consultas são confirmadas imediatamente após o agendamento.</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Clock className="mt-1 h-4 w-4 text-primary" />
+                  <p>Você pode cancelar até 24 horas antes do horário marcado.</p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Stethoscope className="mt-1 h-4 w-4 text-primary" />
+                  <p>Profissionais adicionam novos horários diariamente. Fique atento às atualizações.</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </main>
+      <Footer />
+
+      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirmar agendamento</DialogTitle>
+            <DialogDescription>
+              Verifique as informações abaixo antes de finalizar a reserva do horário selecionado.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {selectedProvider && (
+              <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/40 p-3 text-sm">
+                <Stethoscope className="h-5 w-5 text-health" />
+                <div>
+                  <p className="font-medium">{`${selectedProvider.profile?.first_name ?? ""} ${selectedProvider.profile?.last_name ?? ""}`.trim() || "Profissional"}</p>
+                  {selectedProvider.profile?.specialty && (
+                    <p className="text-muted-foreground">{selectedProvider.profile.specialty}</p>
+                  )}
+                </div>
+              </div>
+            )}
+            {selectedSlot && (
+              <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/40 p-3 text-sm">
+                <CalendarIcon className="h-5 w-5 text-primary" />
+                <div>
+                  <p className="font-medium">{format(new Date(selectedSlot.start_time), "dd/MM/yyyy 'às' HH:mm")}</p>
+                  <p className="text-muted-foreground">Término às {format(new Date(selectedSlot.end_time), "HH:mm")}</p>
+                </div>
+              </div>
+            )}
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="notes">
+                Observações para o profissional (opcional)
+              </label>
+              <Textarea
+                id="notes"
+                placeholder="Inclua informações relevantes ou sintomas que gostaria de destacar."
+                value={bookingNotes}
+                onChange={(event) => setBookingNotes(event.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={() => setIsConfirmOpen(false)} disabled={bookAppointment.isPending}>
+              Voltar
+            </Button>
+            <Button onClick={handleConfirmBooking} disabled={!selectedSlot || bookAppointment.isPending}>
+              {bookAppointment.isPending ? "Confirmando..." : "Confirmar consulta"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isAuthDialogOpen} onOpenChange={setIsAuthDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Faça login para continuar</DialogTitle>
+            <DialogDescription>
+              É necessário estar autenticado para reservar um horário. Entre na sua conta ou crie um cadastro rapidamente.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={() => setIsAuthDialogOpen(false)}>
+              Fechar
+            </Button>
+            <Button onClick={() => navigate("/auth")}>Ir para autenticação</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isRoleDialogOpen} onOpenChange={setIsRoleDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Perfil de usuário não autorizado</DialogTitle>
+            <DialogDescription>
+              Apenas pacientes podem agendar consultas. Acesse com uma conta de paciente ou entre em contato com o suporte.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={() => setIsRoleDialogOpen(false)}>
+              Entendi
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default Schedule;

--- a/supabase/migrations/20250202120000_schedule_tables.sql
+++ b/supabase/migrations/20250202120000_schedule_tables.sql
@@ -1,0 +1,211 @@
+-- Providers, availability slots, and appointments schema extension
+
+-- Create enums for slot and appointment status if not exists
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'slot_status') THEN
+    CREATE TYPE public.slot_status AS ENUM ('available', 'booked', 'unavailable');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_status') THEN
+    CREATE TYPE public.appointment_status AS ENUM ('booked', 'cancelled', 'completed');
+  END IF;
+END $$;
+
+-- Providers table
+CREATE TABLE IF NOT EXISTS public.providers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  profile_id UUID NOT NULL UNIQUE REFERENCES public.profiles(id) ON DELETE CASCADE,
+  specialty TEXT,
+  city TEXT,
+  state TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Availability slots table
+CREATE TABLE IF NOT EXISTS public.availability_slots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider_id UUID NOT NULL REFERENCES public.providers(id) ON DELETE CASCADE,
+  start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  status slot_status NOT NULL DEFAULT 'available',
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  UNIQUE (provider_id, start_time)
+);
+
+-- Appointments table
+CREATE TABLE IF NOT EXISTS public.appointments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slot_id UUID NOT NULL UNIQUE REFERENCES public.availability_slots(id) ON DELETE CASCADE,
+  provider_id UUID NOT NULL REFERENCES public.providers(id) ON DELETE CASCADE,
+  patient_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status appointment_status NOT NULL DEFAULT 'booked',
+  notes TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.providers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.availability_slots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.appointments ENABLE ROW LEVEL SECURITY;
+
+-- Providers policies
+CREATE POLICY "Providers are viewable by all" ON public.providers
+  FOR SELECT USING (true);
+
+CREATE POLICY "Providers manage own record" ON public.providers
+  FOR ALL
+  USING (auth.uid() = user_id OR public.has_role(auth.uid(), 'admin'))
+  WITH CHECK (auth.uid() = user_id OR public.has_role(auth.uid(), 'admin'));
+
+-- Availability slot policies
+CREATE POLICY "Slots are viewable by all" ON public.availability_slots
+  FOR SELECT USING (true);
+
+CREATE POLICY "Providers manage own slots" ON public.availability_slots
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.providers p
+      WHERE p.id = provider_id AND (p.user_id = auth.uid() OR public.has_role(auth.uid(), 'admin'))
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.providers p
+      WHERE p.id = provider_id AND (p.user_id = auth.uid() OR public.has_role(auth.uid(), 'admin'))
+    )
+  );
+
+-- Appointment policies
+CREATE POLICY "Patients and providers can view appointments" ON public.appointments
+  FOR SELECT
+  USING (
+    auth.uid() = patient_id
+    OR EXISTS (
+      SELECT 1 FROM public.providers p
+      WHERE p.id = provider_id AND (p.user_id = auth.uid() OR public.has_role(auth.uid(), 'admin'))
+    )
+    OR public.has_role(auth.uid(), 'admin')
+  );
+
+CREATE POLICY "Patients create appointments" ON public.appointments
+  FOR INSERT
+  WITH CHECK (auth.uid() = patient_id OR public.has_role(auth.uid(), 'admin'));
+
+CREATE POLICY "Patients and providers update appointments" ON public.appointments
+  FOR UPDATE
+  USING (
+    auth.uid() = patient_id
+    OR EXISTS (
+      SELECT 1 FROM public.providers p
+      WHERE p.id = provider_id AND (p.user_id = auth.uid() OR public.has_role(auth.uid(), 'admin'))
+    )
+    OR public.has_role(auth.uid(), 'admin')
+  )
+  WITH CHECK (
+    auth.uid() = patient_id
+    OR EXISTS (
+      SELECT 1 FROM public.providers p
+      WHERE p.id = provider_id AND (p.user_id = auth.uid() OR public.has_role(auth.uid(), 'admin'))
+    )
+    OR public.has_role(auth.uid(), 'admin')
+  );
+
+-- Update triggers for timestamp columns
+CREATE TRIGGER update_providers_updated_at
+  BEFORE UPDATE ON public.providers
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_slots_updated_at
+  BEFORE UPDATE ON public.availability_slots
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_appointments_updated_at
+  BEFORE UPDATE ON public.appointments
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Booking helper function
+CREATE OR REPLACE FUNCTION public.book_appointment(slot_id UUID, notes TEXT DEFAULT NULL)
+RETURNS public.appointments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  slot_record public.availability_slots%ROWTYPE;
+  appointment_record public.appointments%ROWTYPE;
+BEGIN
+  SELECT * INTO slot_record
+  FROM public.availability_slots
+  WHERE id = slot_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Availability slot not found';
+  END IF;
+
+  IF slot_record.status <> 'available' THEN
+    RAISE EXCEPTION 'Slot is not available for booking';
+  END IF;
+
+  INSERT INTO public.appointments (slot_id, provider_id, patient_id, status, notes)
+  VALUES (slot_record.id, slot_record.provider_id, auth.uid(), 'booked', notes)
+  RETURNING * INTO appointment_record;
+
+  UPDATE public.availability_slots
+  SET status = 'booked'
+  WHERE id = slot_record.id;
+
+  RETURN appointment_record;
+END;
+$$;
+
+-- Appointment cancellation helper
+CREATE OR REPLACE FUNCTION public.cancel_appointment(appointment_id UUID)
+RETURNS public.appointments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  appointment_record public.appointments%ROWTYPE;
+BEGIN
+  SELECT * INTO appointment_record
+  FROM public.appointments
+  WHERE id = appointment_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Appointment not found';
+  END IF;
+
+  IF appointment_record.status = 'cancelled' THEN
+    RETURN appointment_record;
+  END IF;
+
+  IF auth.uid() <> appointment_record.patient_id THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.providers p
+      WHERE p.id = appointment_record.provider_id AND (p.user_id = auth.uid() OR public.has_role(auth.uid(), 'admin'))
+    ) THEN
+      RAISE EXCEPTION 'You do not have permission to cancel this appointment';
+    END IF;
+  END IF;
+
+  UPDATE public.appointments
+  SET status = 'cancelled'
+  WHERE id = appointment_id
+  RETURNING * INTO appointment_record;
+
+  UPDATE public.availability_slots
+  SET status = 'available'
+  WHERE id = appointment_record.slot_id;
+
+  RETURN appointment_record;
+END;
+$$;


### PR DESCRIPTION
## Summary
- extend the Supabase schema with providers, availability slots, appointments, and transactional booking helpers while updating generated types
- add typed React Query utilities and a new Schedule page so patients can filter providers, select slots, and confirm appointments
- expose the scheduling flow through updated routing and header/hero calls to action

## Testing
- npm run build
- npm run lint *(fails: existing lint errors in legacy files)*

------
https://chatgpt.com/codex/tasks/task_b_68db252f3d208327aa12120eda986b68